### PR TITLE
後半の第1章（面談日程のCRUD機能）

### DIFF
--- a/app/assets/javascripts/interviews.coffee
+++ b/app/assets/javascripts/interviews.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/interviews.scss
+++ b/app/assets/stylesheets/interviews.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the interviews controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -1,0 +1,44 @@
+class InterviewsController < ApplicationController
+  before_action :authenticate_user!
+
+  def index
+    @interviews = current_user.interview.all.order(datetime: :asc)
+  end
+
+  def edit
+    @interview = Interview.find_by(user_id: current_user.id)
+  end
+
+  def update
+    @interview = Interview.find(params[:id])
+    @interview.update(interview_params)
+    if @interview.save
+      flash[:notice] = "面接が編集されました"
+      redirect_to("/interviews/#{@interview.id}/edit")
+    else
+      flash[:notice] = @interview.errors.full_messages
+      render("interviews/#{@interview.id}/edit")
+    end
+  end
+
+  def destroy
+    @interview = Interview.find(params[:id])
+    @interview.destroy
+    redirect_to("/interviews")
+  end
+
+  def new
+    @interview = Interview.new
+  end
+
+  def create
+    @interview = Interview.new(interview_params)
+    @interview.save
+    flash[:notice] = "面接が作成されました"
+    redirect_to("/interviews")
+  end
+
+  def interview_params
+    params.require(:interview).permit(:datetime).merge(user_id: current_user.id)
+  end
+end

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -6,25 +6,21 @@ class InterviewsController < ApplicationController
   end
 
   def edit
-    @interview = Interview.find_by(user_id: current_user.id)
+    @interview = Interview.find_by(id: params[:id])
   end
 
   def update
     @interview = Interview.find(params[:id])
-    @interview.update(interview_params)
-    if @interview.save
-      flash[:notice] = "面接が編集されました"
-      redirect_to("/interviews/#{@interview.id}/edit")
+    if @interview.update(interview_params)
+      redirect_to("/users/#{current_user.id}/interviews", notice: "面接が編集されました")
     else
-      flash[:notice] = @interview.errors.full_messages
-      render("interviews/#{@interview.id}/edit")
+      render(:edit, notice: @interview.errors.full_messages)
     end
   end
 
   def destroy
-    @interview = Interview.find(params[:id])
-    @interview.destroy
-    redirect_to("/interviews")
+    Interview.find(params[:id]).destroy
+    redirect_to("/users/#{current_user.id}/interviews", notice: "面接を削除しました")
   end
 
   def new
@@ -32,10 +28,8 @@ class InterviewsController < ApplicationController
   end
 
   def create
-    @interview = Interview.new(interview_params)
-    @interview.save
-    flash[:notice] = "面接が作成されました"
-    redirect_to("/interviews")
+    Interview.create(interview_params)
+    redirect_to("/users/#{current_user.id}/interviews", notice: "面接が作成されました")
   end
 
   def interview_params

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -28,11 +28,11 @@ class InterviewsController < ApplicationController
   end
 
   def create
-    Interview.create(interview_params)
+    current_user.interview.create(interview_params)
     redirect_to user_interviews_path, notice: "面接が作成されました"
   end
 
   def interview_params
-    params.require(:interview).permit(:datetime).merge(user_id: current_user.id)
+    params.require(:interview).permit(:datetime)
   end
 end

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -12,15 +12,15 @@ class InterviewsController < ApplicationController
   def update
     @interview = Interview.find(params[:id])
     if @interview.update(interview_params)
-      redirect_to("/users/#{current_user.id}/interviews", notice: "面接が編集されました")
+      redirect_to user_interviews_path, notice: "面接が編集されました"
     else
-      render(:edit, notice: @interview.errors.full_messages)
+      render :edit, notice: @interview.errors.full_messages
     end
   end
 
   def destroy
     Interview.find(params[:id]).destroy
-    redirect_to("/users/#{current_user.id}/interviews", notice: "面接を削除しました")
+    redirect_to user_interviews_path, notice: "面接を削除しました"
   end
 
   def new
@@ -29,7 +29,7 @@ class InterviewsController < ApplicationController
 
   def create
     Interview.create(interview_params)
-    redirect_to("/users/#{current_user.id}/interviews", notice: "面接が作成されました")
+    redirect_to user_interviews_path, notice: "面接が作成されました"
   end
 
   def interview_params

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -11,8 +11,7 @@ class ProfilesController < ApplicationController
   def update
     @user = User.find_by(id: params[:id])
     if @user.update(profile_params)
-      flash[:notice] = "プロフィールを編集しました"
-      redirect_to("/profiles/#{@user.id}/edit")
+      redirect_to("/profiles/#{@user.id}/edit", notice: "プロフィールを編集しました")
     else
       render(:edit)
     end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -11,9 +11,9 @@ class ProfilesController < ApplicationController
   def update
     @user = User.find_by(id: params[:id])
     if @user.update(profile_params)
-      redirect_to("/profiles/#{@user.id}/edit", notice: "プロフィールを編集しました")
+      redirect_to edit_profile_path, notice: "プロフィールを編集しました"
     else
-      render(:edit)
+      render :edit
     end
   end
 

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,10 +1,11 @@
 class ProfilesController < ApplicationController
+  before_action :authenticate_user!
 
   def index
   end
 
   def edit
-    @user = User.find_by(id: current_user.id)
+    @user = User.find(current_user.id)
   end
 
   def update

--- a/app/helpers/interviews_helper.rb
+++ b/app/helpers/interviews_helper.rb
@@ -1,0 +1,2 @@
+module InterviewsHelper
+end

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -1,0 +1,5 @@
+class Interview < ApplicationRecord
+  belongs_to :user
+
+  validates :datetime, {presence: true}
+end

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -1,5 +1,5 @@
 class Interview < ApplicationRecord
   belongs_to :user
 
-  validates :datetime, {presence: true}
+  validates :datetime, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,4 +5,6 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :trackable, :validatable
 
   enum gender: {man: 0, women: 1}
+
+  has_many :interview, dependent: :destroy
 end

--- a/app/views/interviews/edit.html.erb
+++ b/app/views/interviews/edit.html.erb
@@ -1,0 +1,14 @@
+<h2>面接日程の編集</h2>
+<p>開始時間</p>
+
+<%= form_for @interview ,url: {action: :update} do |f| %>
+
+  <div class="field">
+    <%= f.datetime_select :datetime, {start_year: 2013, end_year: 2023} %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "登録" %>
+  </div>
+
+<% end %>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -1,10 +1,10 @@
 <h2><%= current_user.name %>さんの面接一覧</h2>
 <% @interviews.each do |interview| %>
   <%= interview.datetime %>
-  <%= link_to("編集", "/interviews/#{interview.id}/edit") %>
-  <%= link_to("削除", "/interviews/#{interview.id}", method: :delete) %>
+  <%= link_to("編集", "/users/#{current_user.id}/interviews/#{interview.id}/edit") %>
+  <%= link_to("削除", "/users/#{current_user.id}/interviews/#{interview.id}", method: :delete) %>
   </br>
 <% end %>
 
 </br>
-<%= link_to("新規面接作成", "/interviews/new") %>
+<%= link_to("新規面接作成", "/users/#{current_user.id}/interviews/new") %>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -1,0 +1,10 @@
+<h2><%= current_user.name %>さんの面接一覧</h2>
+<% @interviews.each do |interview| %>
+  <%= interview.datetime %>
+  <%= link_to("編集", "/interviews/#{interview.id}/edit") %>
+  <%= link_to("削除", "/interviews/#{interview.id}", method: :delete) %>
+  </br>
+<% end %>
+
+</br>
+<%= link_to("新規面接作成", "/interviews/new") %>

--- a/app/views/interviews/new.html.erb
+++ b/app/views/interviews/new.html.erb
@@ -1,0 +1,14 @@
+<h2>新規面接</h2>
+<p>開始時間</p>
+
+<%= form_for @interview ,url: {action: :create} do |f| %>
+
+  <div class="field">
+    <%= f.datetime_select :datetime, {start_year: 2013, end_year: 2023} %>
+  </div>
+
+  <div class="actions">
+    <%= f.submit "登録" %>
+  </div>
+
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,7 +20,7 @@
           <%= link_to("プロフィール", "/profiles/#{current_user.id}/edit") %>
         </li>
         <li>
-          <%= link_to("自分の面接一覧", "/") %>
+          <%= link_to("自分の面接一覧", "/interviews") %>
         </li>
         <li>
           <%= link_to("メール", "/") %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -20,10 +20,7 @@
           <%= link_to("プロフィール", "/profiles/#{current_user.id}/edit") %>
         </li>
         <li>
-          <%= link_to("自分の面接一覧", "/interviews") %>
-        </li>
-        <li>
-          <%= link_to("メール", "/") %>
+          <%= link_to("自分の面接一覧", "/users/#{current_user.id}/interviews") %>
         </li>
         <li>
           <%= link_to("ログアウト", "/users/sign_out", {method: :delete}) %>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,6 +1,6 @@
 <h2>プロフィールページ</h2>
 
-<%= form_for @user ,:url => {:action => :update} do |f| %>
+<%= form_for @user ,url: {action: :update} do |f| %>
 
   <div class="field">
     <%= f.label :email %><br />
@@ -14,7 +14,7 @@
 
   <div class="field">
     <%= f.label :birthday %><br />
-    <%= f.date_select :birthday, {:start_year => 1950, :end_year => 2000}, value: @user.birthday %>
+    <%= f.date_select :birthday, {start_year: 1950, end_year: 2000}, value: @user.birthday %>
   </div>
 
   <div class="field">

--- a/config/application.rb
+++ b/config/application.rb
@@ -27,5 +27,8 @@ module ENavigator
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+
+    #時間表示を日本時間に変更
+    config.time_zone = 'Tokyo'
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
-    root to: 'profiles#index'
-    devise_for :users
-    resources :profiles
+  root to: 'profiles#index'
+
+  devise_for :users
+  resources :profiles
+  resources :interviews
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,8 @@ Rails.application.routes.draw do
   root to: 'profiles#index'
 
   devise_for :users
+  resources :users do
+    resources :interviews
+  end
   resources :profiles
-  resources :interviews
 end

--- a/db/migrate/20180613060726_create_interviews.rb
+++ b/db/migrate/20180613060726_create_interviews.rb
@@ -1,0 +1,8 @@
+class CreateInterviews < ActiveRecord::Migration[5.1]
+  def change
+    create_table :interviews do |t|
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20180613062315_add_column_to_interviews.rb
+++ b/db/migrate/20180613062315_add_column_to_interviews.rb
@@ -1,0 +1,7 @@
+class AddColumnToInterviews < ActiveRecord::Migration[5.1]
+  def change
+    add_column :interviews, :date, :date
+    add_column :interviews, :status, :integer
+    add_column :interviews, :user_id, :integer
+  end
+end

--- a/db/migrate/20180613154807_change_date_column_to_datetime.rb
+++ b/db/migrate/20180613154807_change_date_column_to_datetime.rb
@@ -1,0 +1,6 @@
+class ChangeDateColumnToDatetime < ActiveRecord::Migration[5.1]
+  def change
+    change_column :interviews, :date, :datetime
+    rename_column :interviews, :date, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180604145523) do
+ActiveRecord::Schema.define(version: 20180613154807) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "interviews", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "datetime"
+    t.integer "status"
+    t.integer "user_id"
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "email", default: "", null: false


### PR DESCRIPTION

やりたかったこと
---

- 自分の面談日程の登録、変更、削除機能の追加
- 面接一覧の表示


やったこと
----

- interviewテーブルの作成、カラムの追加
- interviewsコントローラの作成
- 面談日程の一覧、登録、編集ページの作成
- リレーションの設定


動作確認方法
---

- 面接日程の登録、編集、削除を行う
- 面接一覧ページを見る


その他
---

リレーションに従ったルーティングにするやり方がわからなかったです。
登録フォームの日時選択欄に2/31などありえない日付のものも入っているのが気になりました。