### PR TITLE
後半の第2章（面談日程の承認or拒否設定機能）

### DIFF
--- a/app/assets/stylesheets/profiles.scss
+++ b/app/assets/stylesheets/profiles.scss
@@ -1,3 +1,12 @@
 // Place all the styles related to the profiles controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+
+table {
+  border-collapse: collapse;
+}
+
+th, td {
+  border: 1px solid #ccc;
+  padding: 10px 30px;
+}

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -2,7 +2,9 @@ class InterviewsController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @interviews = current_user.interview.all.order(datetime: :asc)
+    @user = User.find(params[:user_id])
+    @interviews = @user.interview.all.order(datetime: :asc)
+    @interview_time = Interview.find_by(status: "approval").datetime.strftime("%Y年%m月%d日%H時%M分")
   end
 
   def edit
@@ -10,6 +12,7 @@ class InterviewsController < ApplicationController
   end
 
   def update
+    Interview.all.update(status: 0)
     @interview = Interview.find(params[:id])
     if @interview.update(interview_params)
       redirect_to user_interviews_path, notice: "面接が編集されました"
@@ -33,6 +36,6 @@ class InterviewsController < ApplicationController
   end
 
   def interview_params
-    params.require(:interview).permit(:datetime)
+    params.require(:interview).permit(:datetime, :status)
   end
 end

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -6,7 +6,7 @@ class InterviewsController < ApplicationController
   def index
     @interviews = @user.interview.all.order(datetime: :asc)
     @interviews_without_approval = @user.interview.where.not(status: :approval).order(datetime: :asc)
-    @approved_interview = @user.interview.approval
+    @approved_interview = @user.interview.approval.last
   end
 
   def edit
@@ -15,7 +15,7 @@ class InterviewsController < ApplicationController
   def update
     @user.interview.all.update(status: :rejection)
     if @interview.update(interview_params)
-      redirect_to :index, notice: "面接が編集されました"
+      redirect_to action: "index", notice: "面接が編集されました"
     else
       render :edit, notice: @interview.errors.full_messages
     end
@@ -23,7 +23,7 @@ class InterviewsController < ApplicationController
 
   def destroy
     @interview.destroy
-    redirect_to :index, notice: "面接を削除しました"
+    redirect_to action: "index", notice: "面接を削除しました"
   end
 
   def new
@@ -32,7 +32,7 @@ class InterviewsController < ApplicationController
 
   def create
     current_user.interview.create(interview_params)
-    redirect_to :index, notice: "面接が作成されました"
+    redirect_to action: "index", notice: "面接が作成されました"
   end
 
   def interview_params

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -12,7 +12,8 @@ class InterviewsController < ApplicationController
   end
 
   def update
-    Interview.all.update(status: 2)
+    @user = User.find(params[:user_id])
+    @user.interview.all.update(status: 2)
     @interview = Interview.find(params[:id])
     if @interview.update(interview_params)
       redirect_to user_interviews_path, notice: "面接が編集されました"

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -1,20 +1,18 @@
 class InterviewsController < ApplicationController
   before_action :authenticate_user!
+  before_action :set_user, only: [:index, :update]
+  before_action :set_interview, only: [:edit, :update, :destroy]
 
   def index
-    @user = User.find(params[:user_id])
     @interviews = @user.interview.all.order(datetime: :asc)
     @approved_interview = @user.interview.find_by(status: "approval")
   end
 
   def edit
-    @interview = Interview.find_by(id: params[:id])
   end
 
   def update
-    @user = User.find(params[:user_id])
     @user.interview.all.update(status: 2)
-    @interview = Interview.find(params[:id])
     if @interview.update(interview_params)
       redirect_to user_interviews_path, notice: "面接が編集されました"
     else
@@ -23,7 +21,7 @@ class InterviewsController < ApplicationController
   end
 
   def destroy
-    Interview.find(params[:id]).destroy
+    @interview.destroy
     redirect_to user_interviews_path, notice: "面接を削除しました"
   end
 
@@ -38,5 +36,13 @@ class InterviewsController < ApplicationController
 
   def interview_params
     params.require(:interview).permit(:datetime, :status)
+  end
+
+  def set_user
+    @user = User.find(params[:user_id])
+  end
+
+  def set_interview
+    @interview = Interview.find(params[:id])
   end
 end

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -5,6 +5,7 @@ class InterviewsController < ApplicationController
 
   def index
     @interviews = @user.interview.all.order(datetime: :asc)
+    @interviews_without_approval = @user.interview.where.not(status: "approval").order(datetime: :asc)
     @approved_interview = @user.interview.find_by(status: "approval")
   end
 

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -12,7 +12,7 @@ class InterviewsController < ApplicationController
   end
 
   def update
-    Interview.all.update(status: 0)
+    Interview.all.update(status: 2)
     @interview = Interview.find(params[:id])
     if @interview.update(interview_params)
       redirect_to user_interviews_path, notice: "面接が編集されました"

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -4,7 +4,7 @@ class InterviewsController < ApplicationController
   def index
     @user = User.find(params[:user_id])
     @interviews = @user.interview.all.order(datetime: :asc)
-    @interview_time = Interview.find_by(status: "approval").datetime.strftime("%Y年%m月%d日%H時%M分")
+    @approved_interview = @user.interview.find_by(status: "approval")
   end
 
   def edit

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -15,7 +15,7 @@ class InterviewsController < ApplicationController
   def update
     @user.interview.all.update(status: :rejection)
     if @interview.update(interview_params)
-      redirect_to action: "index", notice: "面接が編集されました"
+      redirect_to({ action: :index }, notice: "面接が編集されました")
     else
       render :edit, notice: @interview.errors.full_messages
     end
@@ -23,7 +23,7 @@ class InterviewsController < ApplicationController
 
   def destroy
     @interview.destroy
-    redirect_to action: "index", notice: "面接を削除しました"
+    redirect_to({ action: :index }, notice: "面接を削除しました")
   end
 
   def new
@@ -32,7 +32,7 @@ class InterviewsController < ApplicationController
 
   def create
     current_user.interview.create(interview_params)
-    redirect_to action: "index", notice: "面接が作成されました"
+    redirect_to({ action: :index }, notice: "面接が作成されました")
   end
 
   def interview_params

--- a/app/controllers/interviews_controller.rb
+++ b/app/controllers/interviews_controller.rb
@@ -5,17 +5,17 @@ class InterviewsController < ApplicationController
 
   def index
     @interviews = @user.interview.all.order(datetime: :asc)
-    @interviews_without_approval = @user.interview.where.not(status: "approval").order(datetime: :asc)
-    @approved_interview = @user.interview.find_by(status: "approval")
+    @interviews_without_approval = @user.interview.where.not(status: :approval).order(datetime: :asc)
+    @approved_interview = @user.interview.approval
   end
 
   def edit
   end
 
   def update
-    @user.interview.all.update(status: 2)
+    @user.interview.all.update(status: :rejection)
     if @interview.update(interview_params)
-      redirect_to user_interviews_path, notice: "面接が編集されました"
+      redirect_to :index, notice: "面接が編集されました"
     else
       render :edit, notice: @interview.errors.full_messages
     end
@@ -23,7 +23,7 @@ class InterviewsController < ApplicationController
 
   def destroy
     @interview.destroy
-    redirect_to user_interviews_path, notice: "面接を削除しました"
+    redirect_to :index, notice: "面接を削除しました"
   end
 
   def new
@@ -32,7 +32,7 @@ class InterviewsController < ApplicationController
 
   def create
     current_user.interview.create(interview_params)
-    redirect_to user_interviews_path, notice: "面接が作成されました"
+    redirect_to :index, notice: "面接が作成されました"
   end
 
   def interview_params

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -2,6 +2,7 @@ class ProfilesController < ApplicationController
   before_action :authenticate_user!
 
   def index
+    @users = User.all
   end
 
   def edit

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -12,7 +12,7 @@ class ProfilesController < ApplicationController
   def update
     @user = User.find_by(id: params[:id])
     if @user.update(profile_params)
-      redirect_to :edit, notice: "プロフィールを編集しました"
+      redirect_to action: "edit", notice: "プロフィールを編集しました"
     else
       render :edit
     end

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -2,7 +2,7 @@ class ProfilesController < ApplicationController
   before_action :authenticate_user!
 
   def index
-    @users = User.all
+    @users = User.where.not(id: current_user.id)
   end
 
   def edit

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -12,7 +12,7 @@ class ProfilesController < ApplicationController
   def update
     @user = User.find_by(id: params[:id])
     if @user.update(profile_params)
-      redirect_to edit_profile_path, notice: "プロフィールを編集しました"
+      redirect_to :edit, notice: "プロフィールを編集しました"
     else
       render :edit
     end

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -6,6 +6,6 @@ class Interview < ApplicationRecord
   validates :datetime, presence: true
 
   def datetime_print
-    self.datetime.strftime("%Y年%m月%d日 %H時%M分")
+    self.datetime.strftime("%Y年%m月%d日  %H時%M分")
   end
 end

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -1,7 +1,7 @@
 class Interview < ApplicationRecord
   belongs_to :user
 
-  enum status: {pending: 0, approval: 1}
+  enum status: {pending: 0, approval: 1, rejection: 2}
 
   validates :datetime, presence: true
 end

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -4,4 +4,8 @@ class Interview < ApplicationRecord
   enum status: {pending: 0, approval: 1, rejection: 2}
 
   validates :datetime, presence: true
+
+  def datetime_print
+    self.datetime.strftime("%Y年%m月%d日 %H時%M分")
+  end
 end

--- a/app/models/interview.rb
+++ b/app/models/interview.rb
@@ -1,5 +1,7 @@
 class Interview < ApplicationRecord
   belongs_to :user
 
+  enum status: {pending: 0, approval: 1}
+
   validates :datetime, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,7 +4,7 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
 
-  enum gender: {man: 0, women: 1}
+  enum gender: {man: 0, woman: 1}
 
   has_many :interview, dependent: :destroy
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,8 +9,7 @@ class User < ApplicationRecord
   has_many :interview, dependent: :destroy
 
   def age
-    if self.birthday
-      (Date.today.strftime("%Y%m%d").to_i - self.birthday.strftime("%Y%m%d").to_i) / 10000
-    end
+    (Date.today.strftime("%Y%m%d").to_i - self.birthday.strftime("%Y%m%d").to_i) / 10000 if self.birthday
+
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,10 @@ class User < ApplicationRecord
   enum gender: {man: 0, women: 1}
 
   has_many :interview, dependent: :destroy
+
+  def age
+    if self.birthday
+      (Date.today.strftime("%Y%m%d").to_i - self.birthday.strftime("%Y%m%d").to_i) / 10000
+    end
+  end
 end

--- a/app/views/interviews/_for_current_user.html.erb
+++ b/app/views/interviews/_for_current_user.html.erb
@@ -6,15 +6,15 @@
     <th></th>
   </tr>
 
-<% @interviews.each do |interview| %>
-  <tr>
-    <td><%= interview.datetime.strftime("%Y年%m月%d日 %H時%M分") %></td>
-    <td><%= interview.status %></td>
-    <td><%= link_to("編集", "/users/#{current_user.id}/interviews/#{interview.id}/edit") %></td>
-    <td><%= link_to("削除", "/users/#{current_user.id}/interviews/#{interview.id}", method: :delete) %></td>
-  </br>
-  </tr>
-<% end %>
+  <% @interviews.each do |interview| %>
+    <tr>
+      <td><%= interview.datetime_print %></td>
+      <td><%= interview.status %></td>
+      <td><%= link_to("編集", "/users/#{current_user.id}/interviews/#{interview.id}/edit") %></td>
+      <td><%= link_to("削除", "/users/#{current_user.id}/interviews/#{interview.id}", method: :delete) %></td>
+    </br>
+    </tr>
+  <% end %>
 
 </table>
 

--- a/app/views/interviews/_for_current_user.html.erb
+++ b/app/views/interviews/_for_current_user.html.erb
@@ -1,0 +1,9 @@
+<% @interviews.each do |interview| %>
+  <%= interview.datetime %>
+  <%= link_to("編集", "/users/#{current_user.id}/interviews/#{interview.id}/edit") %>
+  <%= link_to("削除", "/users/#{current_user.id}/interviews/#{interview.id}", method: :delete) %>
+  </br>
+<% end %>
+
+</br>
+<%= link_to("新規面接作成", "/users/#{current_user.id}/interviews/new") %>

--- a/app/views/interviews/_for_current_user.html.erb
+++ b/app/views/interviews/_for_current_user.html.erb
@@ -1,9 +1,22 @@
+<table>
+  <tr>
+    <th>面接開始時間</th>
+    <th>承認状態</th>
+    <th></th>
+    <th></th>
+  </tr>
+
 <% @interviews.each do |interview| %>
-  <%= interview.datetime %>
-  <%= link_to("編集", "/users/#{current_user.id}/interviews/#{interview.id}/edit") %>
-  <%= link_to("削除", "/users/#{current_user.id}/interviews/#{interview.id}", method: :delete) %>
+  <tr>
+    <td><%= interview.datetime.strftime("%Y年%m月%d日 %H時%M分") %></td>
+    <td><%= interview.status %></td>
+    <td><%= link_to("編集", "/users/#{current_user.id}/interviews/#{interview.id}/edit") %></td>
+    <td><%= link_to("削除", "/users/#{current_user.id}/interviews/#{interview.id}", method: :delete) %></td>
   </br>
+  </tr>
 <% end %>
+
+</table>
 
 </br>
 <%= link_to("新規面接作成", "/users/#{current_user.id}/interviews/new") %>

--- a/app/views/interviews/_for_others.html.erb
+++ b/app/views/interviews/_for_others.html.erb
@@ -7,7 +7,7 @@
   <% end %>
 </p>
 <p>面接日程を変更する場合は以下から選んでください。</p>
-<% @interviews.each do |interview| %>
+<% @interviews_without_approval.each do |interview| %>
   <%= form_for [@user, interview] do |f| %>
     <%= f.hidden_field :status, value: "approval" %>
     <%= f.submit(interview.datetime.strftime("%Y年%m月%d日 %H時%M分"), data: {confirm: interview.datetime.strftime("%Y年%m月%d日 %H時%M分") + "で面接を確定していいですか？"}) %>

--- a/app/views/interviews/_for_others.html.erb
+++ b/app/views/interviews/_for_others.html.erb
@@ -1,10 +1,16 @@
 <h3>現在の面接日程</h3>
-<p><%= @interview_time %>に面接が設定されています。</p>
+<p>
+  <% if @approved_interview %>
+  <%= @approved_interview.datetime.strftime("%Y年%m月%d日%H時%M分") %>に面接が設定されています。
+  <% else %>
+  <%= "面接は設定されていません" %>
+  <% end %>
+</p>
 <p>面接日程を変更する場合は以下から選んでください。</p>
 <% @interviews.each do |interview| %>
   <%= form_for [@user, interview] do |f| %>
     <%= f.hidden_field :status, value: "approval" %>
-    <%= f.submit(interview.datetime.strftime("%Y年%m月%d日%H時%M分")) %>
+    <%= f.submit(interview.datetime.strftime("%Y年%m月%d日 %H時%M分"), data: {confirm: interview.datetime.strftime("%Y年%m月%d日 %H時%M分") + "で面接を確定していいですか？"}) %>
     </br>
   <% end %>
 <% end %>

--- a/app/views/interviews/_for_others.html.erb
+++ b/app/views/interviews/_for_others.html.erb
@@ -10,7 +10,7 @@
 <% @interviews_without_approval.each do |interview| %>
   <%= form_for [@user, interview] do |f| %>
     <%= f.hidden_field :status, value: "approval" %>
-    <%= f.submit(interview.datetime_print, data: {confirm: interview.datetime.strftime("%Y年%m月%d日 %H時%M分") + "で面接を確定していいですか？"}) %>
+    <%= f.submit(interview.datetime_print, data: {confirm: interview.datetime_print + "で面接を確定していいですか？"}) %>
     </br>
   <% end %>
 <% end %>

--- a/app/views/interviews/_for_others.html.erb
+++ b/app/views/interviews/_for_others.html.erb
@@ -1,16 +1,16 @@
 <h3>現在の面接日程</h3>
 <p>
   <% if @approved_interview %>
-  <%= @approved_interview.datetime.strftime("%Y年%m月%d日%H時%M分") %>に面接が設定されています。
+    <%= @approved_interview.datetime_print %>に面接が設定されています。
   <% else %>
-  <%= "面接は設定されていません" %>
+    <%= "面接は設定されていません" %>
   <% end %>
 </p>
 <p>面接日程を変更する場合は以下から選んでください。</p>
 <% @interviews_without_approval.each do |interview| %>
   <%= form_for [@user, interview] do |f| %>
     <%= f.hidden_field :status, value: "approval" %>
-    <%= f.submit(interview.datetime.strftime("%Y年%m月%d日 %H時%M分"), data: {confirm: interview.datetime.strftime("%Y年%m月%d日 %H時%M分") + "で面接を確定していいですか？"}) %>
+    <%= f.submit(interview.datetime_print, data: {confirm: interview.datetime.strftime("%Y年%m月%d日 %H時%M分") + "で面接を確定していいですか？"}) %>
     </br>
   <% end %>
 <% end %>

--- a/app/views/interviews/_for_others.html.erb
+++ b/app/views/interviews/_for_others.html.erb
@@ -1,0 +1,10 @@
+<h3>現在の面接日程</h3>
+<p><%= @interview_time %>に面接が設定されています。</p>
+<p>面接日程を変更する場合は以下から選んでください。</p>
+<% @interviews.each do |interview| %>
+  <%= form_for [@user, interview] do |f| %>
+    <%= f.hidden_field :status, value: "approval" %>
+    <%= f.submit(interview.datetime.strftime("%Y年%m月%d日%H時%M分")) %>
+    </br>
+  <% end %>
+<% end %>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -1,10 +1,6 @@
-<h2><%= current_user.name %>さんの面接一覧</h2>
-<% @interviews.each do |interview| %>
-  <%= interview.datetime %>
-  <%= link_to("編集", "/users/#{current_user.id}/interviews/#{interview.id}/edit") %>
-  <%= link_to("削除", "/users/#{current_user.id}/interviews/#{interview.id}", method: :delete) %>
-  </br>
+<h2><%= @user.name %>さんの面接一覧</h2>
+<% if @user == current_user %>
+<%=render "for_current_user" %>
+<% else %>
+<%=render "for_others" %>
 <% end %>
-
-</br>
-<%= link_to("新規面接作成", "/users/#{current_user.id}/interviews/new") %>

--- a/app/views/interviews/index.html.erb
+++ b/app/views/interviews/index.html.erb
@@ -1,6 +1,6 @@
 <h2><%= @user.name %>さんの面接一覧</h2>
 <% if @user == current_user %>
-<%=render "for_current_user" %>
+  <%=render "for_current_user" %>
 <% else %>
-<%=render "for_others" %>
+  <%=render "for_others" %>
 <% end %>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -18,7 +18,12 @@
     <td><%= user.age %></td>
     <td><%= user.gender %></td>
     <td><%= user.school %></td>
-    <td><%= user.interview.find_by(status: "approval").datetime.strftime("%Y年%m月%d日%H時%M分") %></td>
+    <td>
+      <% interview = user.interview.find_by(status: "approval") %>
+      <% if interview %>
+      <%= interview.datetime.strftime("%Y年%m月%d日%H時%M分") %>
+      <% end %>
+    </td>
     <td><%= link_to("面接一覧", "/users/#{user.id}/interviews") %></td>
   </tr>
   <% end %>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -18,7 +18,7 @@
     <td><%= user.age %></td>
     <td><%= user.gender %></td>
     <td><%= user.school %></td>
-    <td>（面接日時）</td>
+    <td><%= user.interview.find_by(status: "approval").datetime.strftime("%Y年%m月%d日%H時%M分") %></td>
     <td><%= link_to("面接一覧", "/users/#{user.id}/interviews") %></td>
   </tr>
   <% end %>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -1,2 +1,25 @@
+<h2>ユーザー一覧</h2>
 
-<h2>トップページ</h2>
+<table>
+  <tr>
+    <th>名前</th>
+    <th>Email</th>
+    <th>年齢</th>
+    <th>性別</th>
+    <th>学校名</th>
+    <th>面接日時</th>
+    <th></th>
+  </tr>
+
+  <% @users.each do |user| %>
+  <tr>
+    <td><%= user.name %></td>
+    <td><%= user.email %></td>
+    <td><%= user.age %></td>
+    <td><%= user.gender %></td>
+    <td><%= user.school %></td>
+    <td>（面接日時）</td>
+    <td><%= link_to("面接一覧", "/users/#{user.id}/interviews") %></td>
+  </tr>
+  <% end %>
+</table>

--- a/app/views/profiles/index.html.erb
+++ b/app/views/profiles/index.html.erb
@@ -12,19 +12,19 @@
   </tr>
 
   <% @users.each do |user| %>
-  <tr>
-    <td><%= user.name %></td>
-    <td><%= user.email %></td>
-    <td><%= user.age %></td>
-    <td><%= user.gender %></td>
-    <td><%= user.school %></td>
-    <td>
-      <% interview = user.interview.find_by(status: "approval") %>
-      <% if interview %>
-      <%= interview.datetime.strftime("%Y年%m月%d日%H時%M分") %>
-      <% end %>
-    </td>
-    <td><%= link_to("面接一覧", "/users/#{user.id}/interviews") %></td>
-  </tr>
+    <tr>
+      <td><%= user.name %></td>
+      <td><%= user.email %></td>
+      <td><%= user.age %></td>
+      <td><%= user.gender %></td>
+      <td><%= user.school %></td>
+      <td>
+        <% interview = user.interview.find_by(status: "approval") %>
+        <% if interview %>
+          <%= interview.datetime.strftime("%Y年%m月%d日%H時%M分") %>
+        <% end %>
+      </td>
+      <td><%= link_to("面接一覧", "/users/#{user.id}/interviews") %></td>
+    </tr>
   <% end %>
 </table>

--- a/db/migrate/20180623035256_change_status_pending_to_interviews.rb
+++ b/db/migrate/20180623035256_change_status_pending_to_interviews.rb
@@ -1,0 +1,5 @@
+class ChangeStatusPendingToInterviews < ActiveRecord::Migration[5.1]
+  def change
+    change_column :interviews, :status, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180613154807) do
+ActiveRecord::Schema.define(version: 20180623035256) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,7 +19,7 @@ ActiveRecord::Schema.define(version: 20180613154807) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "datetime"
-    t.integer "status"
+    t.integer "status", default: 0
     t.integer "user_id"
   end
 


### PR DESCRIPTION
やりたかったこと
---

- 自分以外のユーザー一覧を表示
- 面接日程一覧の表示の出し分け
- 面接の状態（保留、承認、拒否）の設定
- 面接官が面接日程を指定できるように


やったこと
----

- トップページをユーザー一覧に変更
- statusカラムにenumで面接の状態を登録できるように
- 自分と他の人の面接一覧をパーシャルで表示わけ


動作確認方法
---

- 自分と他人の面接一覧ページを見る
- 面接官として他のユーザーの面接日程の承認をする
- 面接日程を追加して表示を確認

その他
---

heroku ：https://e-navigator-ys0921.herokuapp.com/
